### PR TITLE
Update sqlite version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem "sqlite3", "~> 1.4"
-
-gem "rspec", "~> 3.10"
-
-gem "pry", "~> 0.14.1"
+gem "sqlite3", "~> 1.6"
+gem "rspec", "~> 3.13"
+gem "pry", "~> 0.14.2"
+gem 'ostruct'
+gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,77 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.3)
     coderay (1.1.3)
-    diff-lcs (1.4.4)
-    method_source (1.0.0)
-    pry (0.14.1)
+    diff-lcs (1.6.2)
+    json (2.13.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    method_source (1.1.0)
+    ostruct (0.6.3)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.4.0)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    regexp_parser (2.11.2)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
-    sqlite3 (1.4.2)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.5)
+    rubocop (1.80.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
+    sqlite3 (1.7.3-aarch64-linux)
+    sqlite3 (1.7.3-arm-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86-linux)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
+    unicode-display_width (3.1.5)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
-  x86_64-darwin-19
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
-  pry (~> 0.14.1)
-  rspec (~> 3.10)
-  sqlite3 (~> 1.4)
+  ostruct
+  pry (~> 0.14.2)
+  rspec (~> 3.13)
+  rubocop
+  sqlite3 (~> 1.6)
 
 BUNDLED WITH
-   2.2.23
+   2.7.1


### PR DESCRIPTION
This pull request updates dependencies in the `Gemfile` to use newer versions and adds new development tools to the project.

Dependency version updates:

* Updated `sqlite3` to version `~> 1.6` for improved compatibility and bug fixes.
* Updated `rspec` to version `~> 3.13` and `pry` to version `~> 0.14.2` for enhanced testing and debugging support.

Addition of new development tools:

* Added `ostruct` and `rubocop` gems to support flexible data structures and enforce code style standards.